### PR TITLE
Add manifest to include license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
We tried to package **pulp-manifest** using the [upstream spec file](https://github.com/theforeman/pulpcore-packaging/blob/rpm/3.16/packages/python-pulp-manifest/python-pulp-manifest.spec).

As a first step we create a source distribution by triggering `python3 setup.py sdist`

Unfortunately the `LICENSE` file isn't included in the source distribution but it is referenced by the spec file.

This PR simply adds a `MANIFEST.in` file to include the `LICENSE` file during packaging.