### PR TITLE
Add support for generating PULP_MANIFEST from S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@ A tool for the Pulp File plugin to generate a PULP_MANIFEST so the directory can
 
 For more information about File plugin, see [its documentation](https://docs.pulpproject.org/pulp_file/).
 
-To generate PULP_MANIFEST for the chose directory run:
+## Usage
 
-`pulp-manifest /path/to/directory/for/which/manifest/needs/to/be/created`
+To generate a PULP_MANIFEST for a local directory, run:
 
+```
+pulp-manifest /path/to/directory/for/which/manifest/needs/to/be/created
+```
+
+To generate a PULP_MANIFEST for an S3 bucket path, use:
+
+```
+pulp-manifest s3://bucket-name/path/to/prefix/
+```
+
+You can also exclude files or directories matching a glob pattern using the `--filter` option:
+
+```
+pulp-manifest /path/to/directory --filter '*.tmp'
+pulp-manifest s3://bucket-name/path --filter '*.log'
+```
+
+This will exclude files or directories matching the given pattern from the generated manifest.

--- a/pulp_manifest/build_manifest.py
+++ b/pulp_manifest/build_manifest.py
@@ -1,35 +1,22 @@
 import argparse
+import fnmatch
 import os
 import sys
+import boto3
+from urllib.parse import urlparse
 from hashlib import sha256
 
 
-def main():
+def write_manifest(file_path, manifest_lines):
     """
-    Main
+    Write the manifest lines to the specified file path.
+
+    :param file_path: str, path to the file where the manifest will be written
+    :param manifest_lines: list of str, lines to write to the manifest file
     """
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "directory",
-        help="A path to the directory where the PULP_MANIFEST" " file should be created.",
-    )
-    args = parser.parse_args()
-    directory = os.path.abspath(args.directory)
-
-    # Remove PULP_MANIFEST if it already exists in the given directory
-    try:
-        os.remove(os.path.join(directory, "PULP_MANIFEST"))
-    except (IOError, OSError):
-        pass
-
-    try:
-        manifest = traverse_dir(directory)
-        with open(os.path.join(directory, "PULP_MANIFEST"), "w+") as fp:
-            for line in manifest:
-                fp.write(line + os.linesep)
-    except (IOError, OSError) as e:
-        print("Couldn't open or write PULP_MANIFEST to directory %s (%s)." % (directory, e))
-        sys.exit(1)
+    with open(file_path, "w", encoding="utf-8") as fp:
+        for line in manifest_lines:
+            fp.write(line + "\n")
 
 
 def get_digest(path):
@@ -45,17 +32,20 @@ def get_digest(path):
     return digest.hexdigest()
 
 
-def traverse_dir(directory):
+def traverse_dir(directory, filter=None):
     """
     Traverse a given directory path and generate the PULP_MANIFEST
     associated with it.
 
     :param directory: str
+    :param filter: str, optional glob pattern to exclude files or directories
     :return: list of pulp manifest items
     """
     manifest = []
     for root, dirs, files in os.walk(directory, followlinks=True):
         for file in files:
+            if filter and fnmatch.fnmatch(file, f"*{filter}*"):
+                continue
             file_path = os.path.join(root, file)
             line = []
 
@@ -64,3 +54,84 @@ def traverse_dir(directory):
             line.append(os.path.getsize(file_path))
             manifest.append(",".join(str(item) for item in line))
     return manifest
+
+
+def traverse_s3(s3_path, filter=None):
+    """
+    Traverse a given S3 bucket path and generate the PULP_MANIFEST
+    associated with it.
+
+    :param s3_path: str
+    :param filter: str, optional glob pattern to exclude files or directories
+    :return: list of pulp manifest items
+    """
+    manifest = []
+    parsed_url = urlparse(s3_path)
+    bucket_name = parsed_url.netloc
+    prefix = parsed_url.path.lstrip("/")
+    print(prefix)
+
+    s3_client = boto3.client("s3")
+    paginator = s3_client.get_paginator("list_objects_v2")
+
+    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                key = obj["Key"]
+                if filter and fnmatch.fnmatch(key, f"*{filter}*"):
+                    continue
+                line = []
+                line.append(key.removeprefix(prefix).lstrip('/')) # Remove the prefix from the key
+                line.append(obj["ETag"].strip('"'))  # ETag is often the MD5 hash
+                line.append(str(obj["Size"]))
+                manifest.append(",".join(str(item) for item in line))
+
+    return manifest
+
+
+def main():
+    """
+    Main
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate a PULP_MANIFEST file for a given directory or S3 bucket path."
+    )
+    parser.add_argument(
+        "directory",
+        help="A path to the directory where the PULP_MANIFEST"
+        " file should be created.",
+    )
+    parser.add_argument(
+        "-f", "--filter",
+        metavar="PATTERN",
+        help="Exclude files or directories matching the given glob pattern from the PULP_MANIFEST."
+    )
+    args = parser.parse_args()
+    directory = args.directory
+    filter = args.filter
+
+    # Remove PULP_MANIFEST if it already exists in the given directory
+    try:
+        os.remove(os.path.join(directory, "PULP_MANIFEST"))
+    except (IOError, OSError):
+        pass
+
+    try:
+        if directory.startswith("s3://"):
+            print(f"Generating PULP_MANIFEST for S3 bucket: {directory} with filter: {filter}")
+            manifest = traverse_s3(directory, filter)
+        else:
+            print(f"Generating PULP_MANIFEST for directory: {directory}")
+            manifest = traverse_dir(directory)
+        write_manifest("PULP_MANIFEST", manifest)
+    except (IOError, OSError) as e:
+        print(
+            "Couldn't open or write PULP_MANIFEST to directory %s (%s)."
+            % (directory, e)
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)


### PR DESCRIPTION
This commit extends the functionality of the PULP_MANIFEST generator to support both local directories and S3 bucket paths. Key updates include:

- Added `traverse_s3()` function to recursively list files in an S3 bucket using boto3 and generate manifest entries.
- Used ETag as a checksum placeholder for S3 objects and included object size.
- Introduced `--filter` option to exclude files or directories matching a glob pattern (applies to both local and S3).
- Refactored logic into `write_manifest()` for clearer separation of concerns.
- Adjusted `main()` to handle S3 paths (`s3://...`) and standard local directories.
- Ensured compatibility by stripping prefix from S3 keys to compute relative paths.